### PR TITLE
ASC-373 Fix bug where different decorators would fail

### DIFF
--- a/pytest_mark_checker.py
+++ b/pytest_mark_checker.py
@@ -39,11 +39,14 @@ class MarkChecker(object):
             if re.search(r'^test_', name):
                 for decorator in node.decorator_list:
                     # I know this is ugly but it works for now
-                    value = decorator.args[0].s
-                    mark_key = decorator.func.attr
-                    decorator_type = decorator.func.value.value.id
-                    if decorator_type == 'pytest' and mark_key == 'test_id':
-                        marked = True
+                    try:
+                        value = decorator.args[0].s
+                        mark_key = decorator.func.attr
+                        decorator_type = decorator.func.value.value.id
+                        if decorator_type == 'pytest' and mark_key == 'test_id':
+                            marked = True
+                    except (AttributeError, IndexError):
+                        pass
                 if not marked:
                     yield (line_num, 0, self.message_M501, type(self))
 

--- a/tests/test_mark_checking.py
+++ b/tests/test_mark_checking.py
@@ -30,3 +30,106 @@ def not_a_test():
     """)
     result = flake8dir.run_flake8(extra_args)
     assert result.out_lines == []
+
+
+def test_different_mark(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+@pytest.mark.foo('bar')
+def test_mark_we_dont_care_about():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_a_skipped_test(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+@pytest.mark.skip(reason='Need implementation')
+def test_a_test_we_will_skip():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_a_mark_with_parametrize(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+@pytest.mark.parametrize(("n", "expected"), [
+    (1, 2),
+    pytest.mark.bar((1, 3)),
+    (2, 3),
+])
+def test_a_parametrized_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_try_first(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+@pytest.mark.tryfirst
+def test_a_try_first_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_xfail(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.xfail(True, reason=None, run=True, raises=None, strict=False)
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+def test_a_xfail_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_usefixtures(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.usefixtures(fixturename1, fixturename2)
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+def test_a_usefixture_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_dont_validate_one_of_many(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.foo
+@pytest.mark.skip(reason='Need implementation')
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+@pytest.mark.parametrize(("n", "expected"), [
+    (1, 2),
+    pytest.mark.bar((1, 3)),
+    (2, 3),
+])
+def test_a_parametrized_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_do_validate_one_of_many(flake8dir):
+    flake8dir.make_example_py("""
+@pytest.mark.foo
+@pytest.mark.skip(reason='Need implementation')
+@pytest.mark.parametrize(("n", "expected"), [
+    (1, 2),
+    pytest.mark.bar((1, 3)),
+    (2, 3),
+])
+def test_a_parametrized_mark():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == ['./example.py:1:1: M501 test definition not marked with test_id']

--- a/tests/test_mark_checking.py
+++ b/tests/test_mark_checking.py
@@ -102,7 +102,7 @@ def test_a_usefixture_mark():
     assert result.out_lines == []
 
 
-def test_dont_validate_one_of_many(flake8dir):
+def test_multiple_marks(flake8dir):
     flake8dir.make_example_py("""
 @pytest.mark.foo
 @pytest.mark.skip(reason='Need implementation')
@@ -119,7 +119,7 @@ def test_a_parametrized_mark():
     assert result.out_lines == []
 
 
-def test_do_validate_one_of_many(flake8dir):
+def test_multiple_marks_no_id(flake8dir):
     flake8dir.make_example_py("""
 @pytest.mark.foo
 @pytest.mark.skip(reason='Need implementation')


### PR DESCRIPTION
- adds new error classes to except when addressing decorators to test definition
- new test cases that cover examples of differnet kinds of mark decorators