### PR TITLE
ASC-358 impliment configuration for pytest-mark-checker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,5 @@ dist: clean ## builds source and wheel package
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
-develop: clean ## install necessary packages to setup a dev environment
+develop: clean install ## install necessary packages to setup a dev environment
 	pip install -r requirements_dev.txt

--- a/Makefile
+++ b/Makefile
@@ -82,5 +82,6 @@ dist: clean ## builds source and wheel package
 install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
-develop: clean install ## install necessary packages to setup a dev environment
-	pip install -r requirements_dev.txt
+develop: clean ## install necessary packages to setup a dev environment
+	pip install -r requirements.txt
+    pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -83,5 +83,5 @@ install: clean ## install the package to the active Python's site-packages
 	python setup.py install
 
 develop: clean ## install necessary packages to setup a dev environment
-	pip install -r requirements.txt
-    pip install -e .
+	pip install -r requirements_dev.txt
+	pip install -e .

--- a/pytest_mark_checker.py
+++ b/pytest_mark_checker.py
@@ -57,9 +57,16 @@ class MarkChecker(object):
                     for err in rule_func(node, rule_name, configured_rule):
                         yield err
 
-    # a 5XX rule checks for the presence of a configured 'pytest_mark'
-    # marks may be numbered up to 50, example: 'pytest_mark49'
     def rule_M5XX(self, node, rule_name, rule_conf):
+        """Read and validate the input file contents.
+        A 5XX rule checks for the presence of a configured 'pytest_mark'
+        Marks may be numbered up to 50, example: 'pytest_mark49'
+
+        Args:
+            node (ast.AST): A node in the ast.
+            rule_name (str): The name of the rule.
+            rule_conf (dict): The dictionary containing the properties of the rule
+        """
         if isinstance(node, ast.FunctionDef):
             marked = False
             line_num = node.lineno

--- a/pytest_mark_checker.py
+++ b/pytest_mark_checker.py
@@ -16,37 +16,64 @@ class MarkChecker(object):
     """
     name = 'pytest-mark-checker'
     version = __version__
+    pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
 
-    message_M501 = 'M501 test definition not marked with test_id'
+    @classmethod
+    def add_options(cls, parser):
+        kwargs = {'action': 'store', 'default': '', 'parse_from_config': True,
+                  'comma_separated_list': True}
+        for num in range(1, 50):
+            parser.add_option(None, "--pytest-mark{}".format(num), **kwargs)
+
+    @classmethod
+    def parse_options(cls, options):
+        d = {}
+        for pytest_mark, dictionary in cls.pytest_marks.iteritems():
+            # retrieve the marks from the passed options
+            mark_data = getattr(options, pytest_mark)
+            if len(mark_data) != 0:
+                parsed_params = {}
+                for single_line in mark_data:
+                    a = [s.strip() for s in single_line.split('=')]
+                    # whitelist the acceptable params
+                    if a[0] in ['name']:
+                        parsed_params[a[0]] = a[1]
+                d[pytest_mark] = parsed_params
+        cls.pytest_marks.update(d)
+        # delete any empty rules
+        cls.pytest_marks = {x:y for x,y in cls.pytest_marks.items() if len(y) > 0}
 
     def __init__(self, tree, *args, **kwargs):
         self.tree = tree
 
     def run(self):
-        rule_funcs = (self.rule_M501,)
+        if len(self.pytest_marks) == 0:
+            message = "M401 no configuration found for {}, please provide configured marks in a flake8 config".format(self.name)
+            yield (0, 0, message, type(self))
+        rule_funcs = (self.rule_M5XX,)
         for node in ast.walk(self.tree):
             for rule_func in rule_funcs:
-                for err in rule_func(node):
-                    yield err
+                for rule_name, configured_rule in self.pytest_marks.iteritems():
+                    for err in rule_func(node, rule_name, configured_rule):
+                        yield err
 
-    def rule_M501(self, node):
+    # a 5XX rule checks for the presence of a configured 'pytest_mark'
+    # marks may be numbered up to 50, example: 'pytest_mark49'
+    def rule_M5XX(self, node, rule_name, rule_conf):
         if isinstance(node, ast.FunctionDef):
-            # TODO use ast.Nodetransformer to add a UUID tag
-            # this should probably be done in a new subclass
             marked = False
             line_num = node.lineno
-            name = node.name
-            if re.search(r'^test_', name):
+            if re.search(r'^test_', node.name):
                 for decorator in node.decorator_list:
-                    # I know this is ugly but it works for now
                     try:
                         value = decorator.args[0].s
                         mark_key = decorator.func.attr
                         decorator_type = decorator.func.value.value.id
-                        if decorator_type == 'pytest' and mark_key == 'test_id':
+                        if decorator_type == 'pytest' and mark_key == rule_conf['name']:
                             marked = True
-                    except (AttributeError, IndexError):
+                    except (AttributeError, IndexError, KeyError):
                         pass
                 if not marked:
-                    yield (line_num, 0, self.message_M501, type(self))
-
+                    code = filter(str.isdigit, str(rule_name)).zfill(2)
+                    message = 'M5{} test definition not marked with {}'.format(code, rule_conf['name'])
+                    yield (line_num, 0, message, type(self))

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,3 +2,4 @@ tox
 flake8
 pytest-flake8dir
 pytest
+pytest-helpers-namespace

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
+import pytest
+
 pytest_plugins = ['helpers_namespace']
 
-import pytest
 
 @pytest.helpers.register
 def assert_lines(expected, observed):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+pytest_plugins = ['helpers_namespace']
+
+import pytest
+
+@pytest.helpers.register
+def assert_lines(expected, observed):
+    e = [str(string) for string in expected]
+    o = [str(string) for string in observed]
+    e.sort()
+    o.sort()
+    assert e == o

--- a/tests/test_mark_checking.py
+++ b/tests/test_mark_checking.py
@@ -3,8 +3,16 @@
 # args to only use checks that raise an 'M' prefixed error
 extra_args = ['--select', 'M']
 
+config = """
+[flake8]
+pytest_mark1 = name=test_id
+               regex=[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
+               autofix=uuid
+"""
+
 
 def test_with_test_id_mark(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 def test_happy_path():
@@ -15,6 +23,7 @@ def test_happy_path():
 
 
 def test_without_test_id_mark(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 def test_happy_path():
     pass
@@ -24,6 +33,7 @@ def test_happy_path():
 
 
 def test_functions_that_are_not_tests(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 def not_a_test():
     pass
@@ -33,6 +43,7 @@ def not_a_test():
 
 
 def test_different_mark(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 @pytest.mark.foo('bar')
@@ -44,6 +55,7 @@ def test_mark_we_dont_care_about():
 
 
 def test_a_skipped_test(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 @pytest.mark.skip(reason='Need implementation')
@@ -55,6 +67,7 @@ def test_a_test_we_will_skip():
 
 
 def test_a_mark_with_parametrize(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 @pytest.mark.parametrize(("n", "expected"), [
@@ -70,6 +83,7 @@ def test_a_parametrized_mark():
 
 
 def test_try_first(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 @pytest.mark.tryfirst
@@ -81,6 +95,7 @@ def test_a_try_first_mark():
 
 
 def test_xfail(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.xfail(True, reason=None, run=True, raises=None, strict=False)
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
@@ -92,6 +107,7 @@ def test_a_xfail_mark():
 
 
 def test_usefixtures(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.usefixtures(fixturename1, fixturename2)
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
@@ -103,6 +119,7 @@ def test_a_usefixture_mark():
 
 
 def test_multiple_marks(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.foo
 @pytest.mark.skip(reason='Need implementation')
@@ -120,6 +137,7 @@ def test_a_parametrized_mark():
 
 
 def test_multiple_marks_no_id(flake8dir):
+    flake8dir.make_setup_cfg(config)
     flake8dir.make_example_py("""
 @pytest.mark.foo
 @pytest.mark.skip(reason='Need implementation')

--- a/tests/test_multiple_configured.py
+++ b/tests/test_multiple_configured.py
@@ -9,7 +9,7 @@ four_marks_config = """
 [flake8]
 pytest_mark1 = name=test_id
                regex=[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
-               autofix=uuid               
+               autofix=uuid
 pytest_mark2 = name=foo
 pytest_mark3 = name=test_name
 pytest_mark4 = name=bla_bla

--- a/tests/test_multiple_configured.py
+++ b/tests/test_multiple_configured.py
@@ -1,0 +1,58 @@
+# -*- encoding:utf-8 -*-
+import pytest
+from pytest_mark_checker import MarkChecker
+
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+four_marks_config = """
+[flake8]
+pytest_mark1 = name=test_id
+               regex=[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
+               autofix=uuid
+               
+pytest_mark2 = name=foo
+
+pytest_mark3 = name=test_name
+
+pytest_mark4 = name=bla_bla
+
+"""
+
+
+def test_some_tests_marked(flake8dir):
+    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
+    flake8dir.make_setup_cfg(four_marks_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+def test_1():
+    pass
+    
+@pytest.mark.test_name('I am a test name')
+def test_2():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    observed = result.out_lines
+    expected = ['./example.py:1:1: M502 test definition not marked with foo',
+                './example.py:1:1: M503 test definition not marked with test_name',
+                './example.py:1:1: M504 test definition not marked with bla_bla',
+                './example.py:5:1: M501 test definition not marked with test_id',
+                './example.py:5:1: M502 test definition not marked with foo',
+                './example.py:5:1: M504 test definition not marked with bla_bla']
+    pytest.helpers.assert_lines(expected, observed)
+
+def test_no_tests_marked(flake8dir):
+    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
+    flake8dir.make_setup_cfg(four_marks_config)
+    flake8dir.make_example_py("""
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    expected = ['./example.py:1:1: M503 test definition not marked with test_name',
+                './example.py:1:1: M502 test definition not marked with foo',
+                './example.py:1:1: M504 test definition not marked with bla_bla',
+                './example.py:1:1: M501 test definition not marked with test_id']
+    observed = result.out_lines
+    pytest.helpers.assert_lines(expected, observed)

--- a/tests/test_multiple_configured.py
+++ b/tests/test_multiple_configured.py
@@ -9,14 +9,10 @@ four_marks_config = """
 [flake8]
 pytest_mark1 = name=test_id
                regex=[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
-               autofix=uuid
-               
+               autofix=uuid               
 pytest_mark2 = name=foo
-
 pytest_mark3 = name=test_name
-
 pytest_mark4 = name=bla_bla
-
 """
 
 
@@ -31,7 +27,7 @@ def test_1():
 @pytest.mark.test_name('I am a test name')
 def test_2():
     pass
-    """)
+""")
     result = flake8dir.run_flake8(extra_args)
     observed = result.out_lines
     expected = ['./example.py:1:1: M502 test definition not marked with foo',

--- a/tests/test_multiple_configured.py
+++ b/tests/test_multiple_configured.py
@@ -23,7 +23,7 @@ def test_some_tests_marked(flake8dir):
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
 def test_1():
     pass
-    
+
 @pytest.mark.test_name('I am a test name')
 def test_2():
     pass
@@ -38,13 +38,14 @@ def test_2():
                 './example.py:5:1: M504 test definition not marked with bla_bla']
     pytest.helpers.assert_lines(expected, observed)
 
+
 def test_no_tests_marked(flake8dir):
     MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
     flake8dir.make_setup_cfg(four_marks_config)
     flake8dir.make_example_py("""
 def test_happy_path():
     pass
-    """)
+""")
     result = flake8dir.run_flake8(extra_args)
     expected = ['./example.py:1:1: M503 test definition not marked with test_name',
                 './example.py:1:1: M502 test definition not marked with foo',

--- a/tests/test_no_configuration.py
+++ b/tests/test_no_configuration.py
@@ -1,0 +1,19 @@
+# -*- encoding:utf-8 -*-
+import flake8
+from pytest_mark_checker import MarkChecker
+import pytest
+
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+
+def test_no_configuration(flake8dir):
+    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
+    flake8dir.make_example_py("""
+def test_there_is_no_configuration():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    expected = ['./example.py:0:1: M401 no configuration found for pytest-mark-checker, please provide configured marks in a flake8 config']
+    observed = result.out_lines
+    pytest.helpers.assert_lines(expected, observed)

--- a/tests/test_no_configuration.py
+++ b/tests/test_no_configuration.py
@@ -1,5 +1,4 @@
 # -*- encoding:utf-8 -*-
-import flake8
 from pytest_mark_checker import MarkChecker
 import pytest
 
@@ -14,6 +13,6 @@ def test_there_is_no_configuration():
     pass
     """)
     result = flake8dir.run_flake8(extra_args)
-    expected = ['./example.py:0:1: M401 no configuration found for pytest-mark-checker, please provide configured marks in a flake8 config']
+    expected = ['./example.py:0:1: M401 no configuration found for pytest-mark-checker, please provide configured marks in a flake8 config']  # noqa: E501
     observed = result.out_lines
     pytest.helpers.assert_lines(expected, observed)

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 basepython = python
 skip_install = true
 deps = flake8
-commands = flake8 pytest-mark-checker tests
+commands = flake8 pytest-mark-checker tests --ignore M
 
 [testenv]
 setenv =


### PR DESCRIPTION
This will enable a user to configure their own pytest mark that they would like to validate the presence of.  In a valid configuration file a user can add the following line to configure a new mark to be validated.

`pytest_mark1 = name=test_id`

Users may configure up to 50 such marks.  