### PR TITLE
ASC-378 impliment mark validation

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,12 @@ pytest_plugins = ['helpers_namespace']
 
 @pytest.helpers.register
 def assert_lines(expected, observed):
+    """A helper to assert that the contents of two arrays are the same
+
+    Args:
+        expected (list): The expected list of strings.
+        observed (list): The observed list of strings.
+    """
     e = [str(string) for string in expected]
     o = [str(string) for string in observed]
     e.sort()
@@ -17,5 +23,9 @@ def assert_lines(expected, observed):
 
 @pytest.yield_fixture(autouse=True)
 def run_around_tests():
+    """A fixture to execute code before and after every test
+    Code before the yield will run before each test.
+    Code after the yield will run after each test.
+    """
     MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+# -*- encoding:utf-8 -*-
+
 import pytest
+from pytest_mark_checker import MarkChecker
 
 pytest_plugins = ['helpers_namespace']
 
@@ -10,3 +13,9 @@ def assert_lines(expected, observed):
     e.sort()
     o.sort()
     assert e == o
+
+
+@pytest.yield_fixture(autouse=True)
+def run_around_tests():
+    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
+    yield

--- a/tests/test_mark_checking.py
+++ b/tests/test_mark_checking.py
@@ -6,8 +6,7 @@ extra_args = ['--select', 'M']
 config = """
 [flake8]
 pytest_mark1 = name=test_id
-               regex=[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}
-               autofix=uuid
+
 """
 
 

--- a/tests/test_match_validation.py
+++ b/tests/test_match_validation.py
@@ -1,0 +1,96 @@
+# -*- encoding:utf-8 -*-
+
+import pytest
+
+# args to only use checks that raise an 'M' prefixed error
+extra_args = ['--select', 'M']
+
+uuid_config = """
+[flake8]
+pytest_mark1 = name=test_id
+               value_match=uuid
+"""
+
+regex_config = """
+[flake8]
+pytest_mark1 = name=test_id
+               value_match=^this_is_a_regex
+"""
+
+complex_config = """
+[flake8]
+pytest_mark1 = name=test_id
+               value_match=^this_is_a_regex
+pytest_mark2 = name=test_other_id
+               value_match=uuid
+"""
+
+
+def test_with_valid_uuid(flake8dir):
+    flake8dir.make_setup_cfg(uuid_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    assert result.out_lines == []
+
+
+def test_without_valid_uuid(flake8dir):
+    flake8dir.make_setup_cfg(uuid_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('this is a bad value')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    expected = ["./example.py:1:1: M601 the mark value 'this is a bad value' does not match the configured value_match, badly formed hexadecimal UUID string"]  # noqa: E501
+    observed = result.out_lines
+    pytest.helpers.assert_lines(expected, observed)
+
+
+def test_regex_match(flake8dir):
+    flake8dir.make_setup_cfg(regex_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('this_is_a_regex')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    observed = result.out_lines
+    expected = []
+    pytest.helpers.assert_lines(expected, observed)
+
+
+def test_regex_does_not_match(flake8dir):
+    flake8dir.make_setup_cfg(regex_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_id('this_should_fail')
+def test_happy_path():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    observed = result.out_lines
+    expected = [r"./example.py:1:1: M601 the mark value 'this_should_fail' does not match the configured value_match, Configured regex: '^this_is_a_regex'"]  # noqa: E501
+    pytest.helpers.assert_lines(expected, observed)
+
+
+def test_multiple_match_regex_and_uuid(flake8dir):
+    flake8dir.make_setup_cfg(complex_config)
+    flake8dir.make_example_py("""
+@pytest.mark.test_other_id('cdd82eab-4284-11e8-bf5c-6c96cfdf5101')
+@pytest.mark.test_id('this_should_fail')
+def test_i_will_fail():
+    pass
+
+@pytest.mark.test_id('this_is_a_regex')
+@pytest.mark.test_other_id('babe2863-4284-11e8-9eca-6c96cfdf5101fail')
+def test_i_will_fail_too():
+    pass
+    """)
+    result = flake8dir.run_flake8(extra_args)
+    observed = result.out_lines
+    expected = [r"./example.py:1:1: M601 the mark value 'this_should_fail' does not match the configured value_match, Configured regex: '^this_is_a_regex'",  # noqa: E501
+                r"./example.py:6:1: M602 the mark value 'babe2863-4284-11e8-9eca-6c96cfdf5101fail' does not match the configured value_match, badly formed hexadecimal UUID string"]  # noqa: E501
+    pytest.helpers.assert_lines(expected, observed)

--- a/tests/test_multiple_configured.py
+++ b/tests/test_multiple_configured.py
@@ -1,6 +1,5 @@
 # -*- encoding:utf-8 -*-
 import pytest
-from pytest_mark_checker import MarkChecker
 
 # args to only use checks that raise an 'M' prefixed error
 extra_args = ['--select', 'M']
@@ -17,7 +16,6 @@ pytest_mark4 = name=bla_bla
 
 
 def test_some_tests_marked(flake8dir):
-    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
     flake8dir.make_setup_cfg(four_marks_config)
     flake8dir.make_example_py("""
 @pytest.mark.test_id('b360c12d-0d47-4cfc-9f9e-5d86c315b1e4')
@@ -40,7 +38,6 @@ def test_2():
 
 
 def test_no_tests_marked(flake8dir):
-    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
     flake8dir.make_setup_cfg(four_marks_config)
     flake8dir.make_example_py("""
 def test_happy_path():

--- a/tests/test_no_configuration.py
+++ b/tests/test_no_configuration.py
@@ -1,5 +1,4 @@
 # -*- encoding:utf-8 -*-
-from pytest_mark_checker import MarkChecker
 import pytest
 
 # args to only use checks that raise an 'M' prefixed error
@@ -7,7 +6,6 @@ extra_args = ['--select', 'M']
 
 
 def test_no_configuration(flake8dir):
-    MarkChecker.pytest_marks = dict.fromkeys(["pytest_mark{}".format(x) for x in range(1, 50)], {})
     flake8dir.make_example_py("""
 def test_there_is_no_configuration():
     pass


### PR DESCRIPTION
- configuration now accepts value_match as a param to given pytest_mark
- value 'uuid' will validate that the passed string is a uuid example: value_match=uuid
- any other value will be treated as a regex and a match will be attempted, white space is not permitted


There is also a testing improvement to the contest.py file. 